### PR TITLE
Add AI-assisted engineering to consulting and training pages

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -177,7 +177,8 @@
       "DevOps practices: CI/CD pipelines, trunk-based vs. GitFlow in practice, and environments that support safe change.",
       "ADRs: when to write them, what to capture, and how to keep them lightweight but useful.",
       "C4 diagrams: using a shared visual language to reason about systems at multiple levels.",
-      "Clean architecture: boundaries, dependency rules, and patterns that keep systems adaptable."
+      "Clean architecture: boundaries, dependency rules, and patterns that keep systems adaptable.",
+      "AI-assisted engineering: integrating AI tools into your workflow to prevent technical debt accumulation, protect architectural boundaries, and support lightweight spec-driven development."
     ],
     "engagementTitle": "Engagement formats",
     "engagement": [
@@ -714,7 +715,7 @@
   },
   "consulting": {
     "pageTitle": "Consulting that helps teams apply workshop principles in real systems",
-    "intro": "Training sticks when teams use it on real systems and real decisions. I offer short, focused consulting engagements that build on the same workshop ideas—ADRs, C4, CI/CD and deployment practices, modular design—so your team can apply them where it counts.",
+    "intro": "Training sticks when teams use it on real systems and real decisions. I offer short, focused consulting engagements that build on the same workshop ideas—ADRs, C4, CI/CD and deployment practices, modular design, and AI-assisted engineering practices—so your team can apply them where it counts.",
     "auditsTitle": "Architecture and practice audits",
     "audits": [
       "Review of your current architecture, deployment setup, and engineering practices, with a focus on what actually blocks delivery or makes change risky.",
@@ -732,6 +733,17 @@
       "1:1 or small-group mentoring for tech leads and senior engineers, aligned with the same concepts as the workshops.",
       "Practical discussions on introducing and sustaining workshop practices—ADRs, boundaries, CI/CD—in your codebase and team.",
       "Feedback on architecture proposals, RFCs, and rollout plans."
+    ],
+    "aiTransformationEyebrow": "New focus area",
+    "aiTransformationTitle": "AI-assisted engineering transformation",
+    "aiTransformationIntro": "AI tooling genuinely helps teams that already have solid engineering practices — and quietly accelerates technical debt for teams that don't. This focus area is about adopting it deliberately.",
+    "aiTransformation": [
+      "AI adoption in the developer workflow: introducing it so it goes beyond \"we have Copilot\" and actually changes how the team works.",
+      "Agentic and LLM-based workflows: when they genuinely help and when they are just expensive autocomplete.",
+      "Team-level AI usage: building shared practices instead of everyone improvising as a random prompt engineer.",
+      "AI and quality: supporting review, testing, and refactoring — not just generating code.",
+      "Diagnosing \"AI isn't delivering\" situations: where it actually breaks — data, process, ownership, or inflated expectations.",
+      "AI adoption anti-patterns: the proof-of-concept marathon that never becomes production reality."
     ],
     "complementsTitle": "How consulting complements training",
     "complementsBody": "Engagements are short and focused. The aim is knowledge transfer and team autonomy: your people learn to run ADR sessions, maintain diagrams, and improve pipelines themselves. The goal is not ongoing dependency—it's enabling your team to own the practices and decisions after we're done."

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -177,7 +177,8 @@
       "DevOps gyakorlatok: CI/CD pipeline-ok, trunk-based vs. GitFlow a gyakorlatban, olyan környezetek, amelyek támogatják a biztonságos változtatásokat.",
       "ADR-ek: mikor érdemes írni, mit rögzítsünk, hogyan marad könnyű súlyú, de használható.",
       "C4 diagramok: közös vizuális nyelv a rendszer különböző szintjeinek megbeszéléséhez.",
-      "Tiszta architektúra: határok, függőségi szabályok és minták, amelyek hosszú távon is mozgásteret hagynak."
+      "Tiszta architektúra: határok, függőségi szabályok és minták, amelyek hosszú távon is mozgásteret hagynak.",
+      "AI-alapú mérnöki gyakorlatok: AI eszközök integrálása a mindennapi workflowba a technikai adósság megelőzésére, az architektúrális határok védelmére és a lightweight spec-driven fejlesztés támogatására."
     ],
     "engagementTitle": "Lehetséges együttműködési formák",
     "engagement": [
@@ -714,7 +715,7 @@
   },
   "consulting": {
     "pageTitle": "Tanácsadás, amely segít a csapatoknak workshop elveket valós rendszerekben alkalmazni",
-    "intro": "A képzés akkor ragad meg igazán, ha valós rendszereken és valós döntéseken használják. Rövid, fókuszált tanácsadási együttműködéseket vállalok, amelyek ugyanazon workshop ötletekre épülnek—ADR-ek, C4, CI/CD és deployment gyakorlatok, moduláris tervezés—így a csapatod ott tudja alkalmazni őket, ahol számít.",
+    "intro": "A képzés akkor ragad meg igazán, ha valós rendszereken és valós döntéseken használják. Rövid, fókuszált tanácsadási együttműködéseket vállalok, amelyek ugyanazon workshop ötletekre épülnek—ADR-ek, C4, CI/CD és deployment gyakorlatok, moduláris tervezés és AI-alapú mérnöki gyakorlatok—így a csapatod ott tudja alkalmazni őket, ahol számít.",
     "auditsTitle": "Architektúra- és gyakorlat-felmérés",
     "audits": [
       "A jelenlegi architektúra, deployment környezet és mérnöki gyakorlatok áttekintése, fókuszálva arra, hogy mi akadályozza a szállítást vagy teszi kockázatossá a változtatást.",
@@ -732,6 +733,17 @@
       "1:1 vagy kis csoportos mentorálás tech lead-ek és senior fejlesztők számára, ugyanazon koncepciók mentén, mint a workshopok.",
       "Gyakorlati beszélgetések arról, hogyan lehet ténylegesen bevezetni és fenntartani új gyakorlatokat valós csapatokban—ADR-ek, határok, CI/CD—a kódbázisban és csapatban.",
       "Visszajelzés architekturális javaslatokra, RFC-kre és implementációs tervekhez."
+    ],
+    "aiTransformationEyebrow": "Új fókuszterület",
+    "aiTransformationTitle": "AI-alapú mérnöki transzformáció",
+    "aiTransformationIntro": "Az AI eszközök azoknak a csapatoknak segítenek igazán, akiknek már szilárd mérnöki gyakorlataik vannak — a többieknél jellemzően csak gyorsítják a technikai adósság felhalmozódását. Ez a fókuszterület arról szól, hogyan vezessük be tudatosan.",
+    "aiTransformation": [
+      "AI adoption a fejlesztői workflow-ban: hogyan vezessük be úgy, hogy ne csak „van Copilotunk” szinten ragadjon meg.",
+      "Agentic / LLM-alapú munkafolyamatok: mikor működnek és mikor csak drága autocomplete.",
+      "Csapat szintű AI-használat: egységes gyakorlatok kialakítása, nem mindenki random prompt-engineer.",
+      "AI és minőség: review, tesztelés, refaktorálás támogatása, nem csak kódgenerálás.",
+      "„AI nem hozza az elvárásokat” helyzetek elemzése: hol törik el — adat, folyamat, ownership, túlzott várakozás.",
+      "AI-bevezetési anti-patternök: a proof-of-concept maraton, amiből sosem lesz production reality."
     ],
     "complementsTitle": "Hogyan egészíti ki a tanácsadás a képzéseket",
     "complementsBody": "Az együttműködések rövidek és fókuszáltak. A cél a tudásátadás és csapat autonómia: az embereitek megtanulják az ADR sessionök vezetését, a diagramok karbantartását és a pipeline-ok fejlesztését maguk. A cél nem tartós függés—az, hogy a csapatod birtokolhassa a gyakorlatokat és döntéseket után, hogy készen vagyunk."

--- a/src/pages/ConsultingPage.vue
+++ b/src/pages/ConsultingPage.vue
@@ -46,6 +46,19 @@ const { t } = useI18n()
     </section>
 
     <section class="section">
+      <div class="ai-highlight">
+        <p class="ai-eyebrow">{{ t('consulting.aiTransformationEyebrow') }}</p>
+        <h2 class="ai-title">{{ t('consulting.aiTransformationTitle') }}</h2>
+        <p class="ai-intro">{{ t('consulting.aiTransformationIntro') }}</p>
+        <ul class="list">
+          <li v-for="item in t('consulting.aiTransformation')" :key="item">
+            {{ item }}
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="section">
       <BaseCard>
         <template #title>
           {{ t('consulting.complementsTitle') }}
@@ -101,6 +114,35 @@ const { t } = useI18n()
 .body {
   margin: 0;
   font-size: 0.9rem;
+}
+
+.ai-highlight {
+  border: 1px solid var(--color-primary-soft);
+  border-left: 4px solid var(--color-primary);
+  background-color: var(--color-primary-soft);
+  border-radius: var(--radius-md);
+  padding: 1.6rem 1.75rem;
+}
+
+.ai-eyebrow {
+  margin: 0 0 0.4rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-primary-strong);
+}
+
+.ai-title {
+  margin: 0 0 0.6rem;
+  font-size: 1.3rem;
+}
+
+.ai-intro {
+  margin: 0 0 1rem;
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+  max-width: 44rem;
 }
 </style>
 


### PR DESCRIPTION
Surface AI-assisted engineering as part of the offering alongside architecture topics:
- New highlighted "AI-assisted engineering transformation" section on the consulting page with six concrete focus points
- AI-assisted engineering added to consulting intro and training topics
- Both EN and HU