### PR TITLE
/slack vanity URL redirects to Slack invite

### DIFF
--- a/public/slack/index.html
+++ b/public/slack/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/png" href="/logo.png" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
+    <title>Redirecting to Slack | letscode.hu</title>
+    <link
+      rel="canonical"
+      href="https://join.slack.com/t/letscodehu/shared_invite/zt-rar6y94y-WUcNmdu9vxUIJz96HZAT9g"
+    />
+    <meta
+      http-equiv="refresh"
+      content="0; url=https://join.slack.com/t/letscodehu/shared_invite/zt-rar6y94y-WUcNmdu9vxUIJz96HZAT9g"
+    />
+    <script>
+      window.location.replace(
+        'https://join.slack.com/t/letscodehu/shared_invite/zt-rar6y94y-WUcNmdu9vxUIJz96HZAT9g'
+      )
+    </script>
+  </head>
+  <body>
+    <p>
+      Redirecting to the letscode.hu Slack…
+      <a href="https://join.slack.com/t/letscodehu/shared_invite/zt-rar6y94y-WUcNmdu9vxUIJz96HZAT9g">
+        Click here if you are not redirected.
+      </a>
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
## What

Adds a `/slack` vanity URL that redirects visitors to the letscode.hu Slack join link:
`https://join.slack.com/t/letscodehu/shared_invite/zt-rar6y94y-WUcNmdu9vxUIJz96HZAT9g`

## How

A static redirect page at `public/slack/index.html` (copied to `dist/slack/index.html` at build time and served directly by GitHub Pages at `/slack`). It:

- Redirects instantly via `window.location.replace` (no back-button trap)
- Falls back to `<meta http-equiv="refresh">` when JS is disabled
- Shows a visible manual link
- Is marked `noindex` and kept out of the sitemap/prerender paths (it's a redirect, not a page)

No router changes needed — this bypasses the SPA entirely, which is what an external redirect wants. GitHub Pages 301-redirects `/slack` → `/slack/` → the redirect page.

## Testing

`npm run build` succeeds and emits `dist/slack/index.html`. Local `vite preview` serves the redirect page at `/slack/` with both redirect mechanisms present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)