### PR TITLE
/slack: landing oldal az azonnali redirect helyett

### DIFF
--- a/public/slack/index.html
+++ b/public/slack/index.html
@@ -1,31 +1,21 @@
 <!doctype html>
-<html lang="en">
+<html lang="hu">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex" />
-    <title>Redirecting to Slack | letscode.hu</title>
-    <link
-      rel="canonical"
-      href="https://join.slack.com/t/letscodehu/shared_invite/zt-rar6y94y-WUcNmdu9vxUIJz96HZAT9g"
-    />
-    <meta
-      http-equiv="refresh"
-      content="0; url=https://join.slack.com/t/letscodehu/shared_invite/zt-rar6y94y-WUcNmdu9vxUIJz96HZAT9g"
-    />
+    <title>letscode.hu Slack</title>
+    <link rel="canonical" href="https://letscode.hu/hu/slack" />
+    <meta http-equiv="refresh" content="0; url=/hu/slack" />
     <script>
-      window.location.replace(
-        'https://join.slack.com/t/letscodehu/shared_invite/zt-rar6y94y-WUcNmdu9vxUIJz96HZAT9g'
-      )
+      window.location.replace('/hu/slack')
     </script>
   </head>
   <body>
     <p>
-      Redirecting to the letscode.hu Slack…
-      <a href="https://join.slack.com/t/letscodehu/shared_invite/zt-rar6y94y-WUcNmdu9vxUIJz96HZAT9g">
-        Click here if you are not redirected.
-      </a>
+      Átirányítás…
+      <a href="/hu/slack">Kattints ide, ha nem irányít át automatikusan.</a>
     </p>
   </body>
 </html>

--- a/src/i18n/hu.json
+++ b/src/i18n/hu.json
@@ -913,6 +913,24 @@
     "contactTitle": "Kérdések",
     "contactBody": "Ha kérdésed van az oldalon történő adatkezeléssel kapcsolatban, kérlek használd a Kapcsolat oldalt."
   },
+  "slack": {
+    "pageTitle": "Csatlakozz a letscode.hu Slack közösséghez",
+    "intro": "A letscode.hu fejlesztői közössége. Csatlakozz — vagy előbb nézz körül az oldalon.",
+    "socialProof": "1000+ fejlesztő már csatlakozott.",
+    "joinCta": "Csatlakozom a Slackhez",
+    "joinNote": "Ingyenes. Nincs spam, csak beszélgetések.",
+    "exploreTitle": "Ha már itt vagy, nézz körül",
+    "exploreIntro": "A közösség az oldal mögötti munkából nőtt ki: workshopok, tanácsadás és cikkek fejlesztői csapatoknak.",
+    "exploreTrainingTitle": "Workshopok és képzések",
+    "exploreTrainingBody": "Gyakorlatorientált workshopok tapasztalt csapatoknak: architektúra döntések, ADR-ek, C4, CI/CD.",
+    "exploreTrainingCta": "Workshopok megnézése →",
+    "exploreConsultingTitle": "Tanácsadás",
+    "exploreConsultingBody": "Rövid, fókuszált együttműködések, hogy ezek a gyakorlatok a saját rendszereitekben is működjenek.",
+    "exploreConsultingCta": "Miben tudok segíteni →",
+    "exploreBlogTitle": "Blog",
+    "exploreBlogBody": "Cikkek szállítási szűk keresztmetszetekről, architekturális döntésekről és AI-alapú fejlesztésről.",
+    "exploreBlogCta": "Cikkek olvasása →"
+  },
   "seo": {
     "defaultOgImageAlt": "Letscode Solutions — képzés és tanácsadás fejlesztői csapatoknak",
     "descriptions": {
@@ -926,7 +944,8 @@
       "contact": "Lépj kapcsolatba a Letscode Solutionsszel képzés, workshop vagy tanácsadás egyeztetéséhez.",
       "caseStudies": "Esettanulmányok valós képzési és tanácsadási munkából: szállítás, tesztelés, architektúra és platformmodernizáció.",
       "blog": "Cikkek CI/CD-ről, szállítási szűk keresztmetszetekről, architekturális döntésekről és a production felé vezető útról.",
-      "privacy": "Hogyan történhet adatkezelés ezen a webhelyen, milyen külső szolgáltatások tölthetők be, és hogyan működnek a süti beállítások."
+      "privacy": "Hogyan történhet adatkezelés ezen a webhelyen, milyen külső szolgáltatások tölthetők be, és hogyan működnek a süti beállítások.",
+      "slack": "Csatlakozz a letscode.hu Slack közösséghez: beszélgetések architektúráról, CI/CD-ről és AI-alapú fejlesztésről fejlesztők között."
     }
   }
 }

--- a/src/pages/SlackPage.vue
+++ b/src/pages/SlackPage.vue
@@ -1,0 +1,158 @@
+<script setup lang="ts">
+import { useI18n } from '../composables/useI18n'
+import BaseCard from '../components/ui/BaseCard.vue'
+import BaseButton from '../components/ui/BaseButton.vue'
+import { trackSlackJoinClick } from '../tracking'
+
+const SLACK_INVITE_URL =
+  'https://join.slack.com/t/letscodehu/shared_invite/zt-rar6y94y-WUcNmdu9vxUIJz96HZAT9g'
+
+const { t, currentLang } = useI18n()
+</script>
+
+<template>
+  <article>
+    <header class="page-header">
+      <h1 class="page-title">
+        {{ t('slack.pageTitle') }}
+      </h1>
+      <p class="page-intro">
+        {{ t('slack.intro') }}
+      </p>
+    </header>
+
+    <section class="section">
+      <div class="join-highlight">
+        <p class="social-proof">{{ t('slack.socialProof') }}</p>
+        <div class="join-actions">
+          <BaseButton
+            as="a"
+            :href="SLACK_INVITE_URL"
+            target="_blank"
+            rel="noopener"
+            @click="trackSlackJoinClick()"
+          >
+            {{ t('slack.joinCta') }}
+          </BaseButton>
+          <p class="join-note">{{ t('slack.joinNote') }}</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <h2 class="explore-title">{{ t('slack.exploreTitle') }}</h2>
+      <p class="explore-intro">{{ t('slack.exploreIntro') }}</p>
+      <div class="grid grid--three">
+        <BaseCard>
+          <template #title>{{ t('slack.exploreTrainingTitle') }}</template>
+          <p class="body">{{ t('slack.exploreTrainingBody') }}</p>
+          <router-link class="card-link" :to="{ name: 'training-en', params: { lang: currentLang } }">
+            {{ t('slack.exploreTrainingCta') }}
+          </router-link>
+        </BaseCard>
+
+        <BaseCard>
+          <template #title>{{ t('slack.exploreConsultingTitle') }}</template>
+          <p class="body">{{ t('slack.exploreConsultingBody') }}</p>
+          <router-link class="card-link" :to="{ name: 'consulting-en', params: { lang: currentLang } }">
+            {{ t('slack.exploreConsultingCta') }}
+          </router-link>
+        </BaseCard>
+
+        <BaseCard>
+          <template #title>{{ t('slack.exploreBlogTitle') }}</template>
+          <p class="body">{{ t('slack.exploreBlogBody') }}</p>
+          <router-link class="card-link" :to="{ name: 'blog-list-en', params: { lang: currentLang } }">
+            {{ t('slack.exploreBlogCta') }}
+          </router-link>
+        </BaseCard>
+      </div>
+    </section>
+  </article>
+</template>
+
+<style scoped>
+.page-header {
+  margin-bottom: 2.25rem;
+}
+
+.page-title {
+  margin: 0 0 0.75rem;
+  font-size: 1.6rem;
+}
+
+.page-intro {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+  max-width: 44rem;
+}
+
+.section {
+  margin-bottom: 2rem;
+}
+
+.join-highlight {
+  border: 1px solid var(--color-primary-soft);
+  border-left: 4px solid var(--color-primary);
+  background-color: var(--color-primary-soft);
+  border-radius: var(--radius-md);
+  padding: 1.6rem 1.75rem;
+}
+
+.social-proof {
+  margin: 0 0 1rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.join-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.join-note {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.explore-title {
+  margin: 0 0 0.5rem;
+  font-size: 1.3rem;
+}
+
+.explore-intro {
+  margin: 0 0 1.25rem;
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+  max-width: 44rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.grid--three {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.body {
+  margin: 0 0 0.75rem;
+  font-size: 0.9rem;
+}
+
+.card-link {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.card-link:hover {
+  text-decoration: underline;
+}
+</style>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -13,6 +13,7 @@ import BlogPage from '../pages/BlogPage.vue'
 import BlogPostDetailPage from '../pages/BlogPostDetailPage.vue'
 import PrivacyPage from '../pages/PrivacyPage.vue'
 import QuizPage from '../pages/QuizPage.vue'
+import SlackPage from '../pages/SlackPage.vue'
 
 const childRoutes: RouteRecordRaw[] = [
   {
@@ -105,6 +106,19 @@ const childRoutes: RouteRecordRaw[] = [
     name: 'blog-post-detail-en',
     component: BlogPostDetailPage,
     meta: { titleKey: 'blog.pageTitle', useChildTitle: true },
+  },
+  {
+    path: 'slack',
+    name: 'slack',
+    component: SlackPage,
+    meta: { titleKey: 'slack.pageTitle', descriptionKey: 'seo.descriptions.slack' },
+    beforeEnter: (_to, _from, next) => {
+      if (typeof window !== 'undefined' && !window.location.pathname.startsWith('/hu/')) {
+        next({ path: '/hu/slack' })
+      } else {
+        next()
+      }
+    },
   },
   {
     path: 'privacy',

--- a/src/seo/prerender-paths.ts
+++ b/src/seo/prerender-paths.ts
@@ -27,6 +27,7 @@ const HU_STATIC_ALIASES: string[] = [
   'kapcsolat',
   'cikkek',
   'quiz',
+  'slack',
 ]
 
 /**

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -299,6 +299,20 @@ export function trackTrainingWorkshopEmailPopupOpen(args: {
   }
 }
 
+export function trackSlackJoinClick() {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  if (loaded.ga && window.gtag) {
+    window.gtag('event', 'slack_join_click')
+  }
+
+  if (loaded.fb && window.fbq) {
+    window.fbq('trackCustom', 'SlackJoinClick')
+  }
+}
+
 export type TrainingWorkshopStripeSource = 'cta_direct' | 'email_popup'
 
 export function trackTrainingWorkshopStripeRedirect(args: {


### PR DESCRIPTION
A /slack mostantól a /hu/slack oldalra visz, ahol a Slack invite gomb mellett CTA kártyák mutatnak a workshop, tanácsadás és blog oldalakra. Így a direkt látogatókról is van analitika (pageview + slack_join_click esemény), és van esélyük körülnézni az oldalon.